### PR TITLE
Replaced 'ssh-agent' by ['ssh-agent','-s'] to fix the issue of missing =

### DIFF
--- a/ssh_agent_setup/__init__.py
+++ b/ssh_agent_setup/__init__.py
@@ -11,7 +11,7 @@ def _killAgent():
     del os.environ[ 'SSH_AGENT_PID' ]
 
 def _setupAgent():
-    process = subprocess.run( 'ssh-agent', stdout = subprocess.PIPE, universal_newlines = True )
+    process = subprocess.run( ['ssh-agent','-s'], stdout = subprocess.PIPE, universal_newlines = True )
     OUTPUT_PATTERN = re.compile(  'SSH_AUTH_SOCK=(?P<socket>[^;]+).*SSH_AGENT_PID=(?P<pid>\d+)', re.MULTILINE | re.DOTALL )
     match = OUTPUT_PATTERN.search( process.stdout )
     if match is None:


### PR DESCRIPTION
~% ssh-agent 
setenv SSH_AUTH_SOCK /tmp/ssh-yJelwe93i4V2/agent.64085;
setenv SSH_AGENT_PID 64086;
echo Agent pid 64086;

~% ssh-agent -s
SSH_AUTH_SOCK=/tmp/ssh-K5pLI0dBxgXW/agent.64087; export SSH_AUTH_SOCK;
SSH_AGENT_PID=64088; export SSH_AGENT_PID;
echo Agent pid 64088;