### PR TITLE
subprocess: redirect command output to the logger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+name: Publish
+on:
+    workflow_dispatch:
+jobs:        
+    publish:
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v2
+            - run:  ls
+            - name: install poetry
+              run:  curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+            - run:  poetry run pip install twine
+            - run:  rm -fr dist/
+            - run:  poetry build -f wheel
+            - run:  poetry run twine upload -u __token__ -p ${{ secrets.PUBLISH_TOKEN }} dist/*whl

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,8 +1,6 @@
 name: Tests
 on:
-    push:
-        branches:
-            - issue_**
+  pull_request:
 jobs:
   Unit-Tests:
     runs-on: ubuntu-20.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssh-agent-setup"
-version = "2.0.0"
+version = "2.0.1"
 description = "set up a working ssh-agent and add keys for any subprocesses you want to run"
 authors = ["Yoav Kleinberger <haarcuba@gmail.com>"]
 license = "MIT"

--- a/ssh_agent_setup/__init__.py
+++ b/ssh_agent_setup/__init__.py
@@ -7,7 +7,9 @@ import atexit
 
 def _kill_agent():
     logging.info('killing previously started ssh-agent')
-    subprocess.run(['ssh-agent', '-k'])
+    process = subprocess.run(['ssh-agent', '-k'], stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT, text=True)
+    logging.info(process.stdout)
     del os.environ['SSH_AUTH_SOCK']
     del os.environ['SSH_AGENT_PID']
 
@@ -35,6 +37,8 @@ def setup():
 
 
 def add_key(key_file):
-    process = subprocess.run(['ssh-add', key_file])
+    process = subprocess.run(['ssh-add', key_file], stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT, text=True)
+    logging.info(process.stdout)
     if process.returncode != 0:
         raise Exception('failed to add the key: {}'.format(key_file))


### PR DESCRIPTION
Right now, ssh_agent_setup has multiple logging outputs:
* info messages passed via `logging.info()`
* stdout output from each `subprocess.run()` calls
* stderr output from each `subprocess.run()` calls

This makes it impossible to "silence" completly the module. In some
cases (such as an automated CI pipeline using concourse [1]), we might
require silence on stdout.

Redirect stdout/stderr from `subprocess.run()` into the logger so that a
module use can control all output of ssh_agent_setup

[1] https://concourse-ci.org/implementing-resource-types.html#resource-check
Signed-off-by: Mattijs Korpershoek <mkorpershoek@baylibre.com>